### PR TITLE
#5 Feature/jwt refresh token

### DIFF
--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/api/AuthApi.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/api/AuthApi.java
@@ -23,10 +23,13 @@ public class AuthApi {
 
     @PostMapping("/login")
     public SuccessResponse authorize(HttpServletResponse response, @Valid @RequestBody LoginDto.Req req) {
-        String jwt = userLoginService.authorize(req);
-        response.setHeader(TokenProvider.AUTHORIZATION_HEADER, "Bearer " + jwt);
+        TokenDto tokenDto = userLoginService.authorize(req);
+        response.setHeader(TokenProvider.AUTHORIZATION_HEADER, "Bearer " + tokenDto.getAccessToken());
+        return SuccessResponse.success(tokenDto);
+    }
 
-        return SuccessResponse.success(new TokenDto(jwt));
-
+    @PostMapping("/token")
+    public SuccessResponse token(String refreshToken) {
+        return SuccessResponse.success(userLoginService.refreshToken(refreshToken));
     }
 }

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/api/AuthApi.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/api/AuthApi.java
@@ -32,4 +32,10 @@ public class AuthApi {
     public SuccessResponse token(String refreshToken) {
         return SuccessResponse.success(userLoginService.refreshToken(refreshToken));
     }
+
+    @PostMapping("/logout")
+    public SuccessResponse logout(String refreshToken) {
+        userLoginService.signout(refreshToken);
+        return SuccessResponse.success();
+    }
 }

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/dao/RefreshTokenRedisRepository.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/dao/RefreshTokenRedisRepository.java
@@ -5,6 +5,6 @@ import com.j2kb.jibapi.domain.user.entity.RefreshToken;
 import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 
-public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, Long> {
+public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, String> {
     Optional<PasswordResetToken> findByEmail(String email);
 }

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/dao/RefreshTokenRedisRepository.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/dao/RefreshTokenRedisRepository.java
@@ -1,0 +1,10 @@
+package com.j2kb.jibapi.domain.user.dao;
+
+import com.j2kb.jibapi.domain.user.entity.PasswordResetToken;
+import com.j2kb.jibapi.domain.user.entity.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, Long> {
+    Optional<PasswordResetToken> findByEmail(String email);
+}

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/dto/JoinDto.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/dto/JoinDto.java
@@ -69,7 +69,7 @@ public class JoinDto {
         private String lastName;
         private LoginType loginType;
         private UserType userType;
-        private String token;
+        private TokenDto token;
 
         public static BasicRes of(User user) {
             return BasicRes.builder()
@@ -130,6 +130,6 @@ public class JoinDto {
         private String lastName;
         private LoginType loginType;
         private UserType userType;
-        private String token;
+        private TokenDto token;
     }
 }

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/dto/TokenDto.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/dto/TokenDto.java
@@ -10,5 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TokenDto {
-    private String token;
+    private String accessToken;
+    private String refreshToken;
 }

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/entity/RefreshToken.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/entity/RefreshToken.java
@@ -1,0 +1,25 @@
+package com.j2kb.jibapi.domain.user.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@Setter
+@RedisHash(value = "RefreshToken", timeToLive = 60 * 5)
+public class RefreshToken {
+
+    @Id
+    @Indexed
+    private String email;
+    private String token;
+
+    @Builder
+    public RefreshToken(String email, String token) {
+        this.email = email;
+        this.token = token;
+    }
+}

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/entity/RefreshToken.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/entity/RefreshToken.java
@@ -5,19 +5,24 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @Setter
-@RedisHash(value = "RefreshToken", timeToLive = 60 * 5)
+@RedisHash(value = "RefreshToken")
 public class RefreshToken {
 
     @Id
     @Indexed
     private String token;
 
+    @TimeToLive
+    private long timeToLive;
+
     @Builder
-    public RefreshToken(String token) {
+    public RefreshToken(String token, long timeToLive) {
         this.token = token;
+        this.timeToLive = timeToLive;
     }
 }

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/entity/RefreshToken.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/entity/RefreshToken.java
@@ -14,12 +14,10 @@ public class RefreshToken {
 
     @Id
     @Indexed
-    private String email;
     private String token;
 
     @Builder
-    public RefreshToken(String email, String token) {
-        this.email = email;
+    public RefreshToken(String token) {
         this.token = token;
     }
 }

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/entity/User.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/entity/User.java
@@ -106,19 +106,14 @@ public class User extends DateAudit {
 
     }
 
-    public Map<String,Object> toClaims(){
-        return ImmutableMap.<String,Object>builder()
-            .put("no"    , getUserNo())
-            .put("email"     , getEmail())
-            .put("type", getUserType())
-            .build();
-    }
-
     public static User valueOf(Claims claims) {
 
         return User.builder()
             .userNo(Long.valueOf(claims.get("no").toString()))
             .email((String) claims.get("email"))
+            .lastName((String) claims.get("lastName"))
+            .firstName((String) claims.get("firstName"))
+            .userType((String) claims.get("userType"))
             .build();
     }
 }

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/enums/TokenType.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/enums/TokenType.java
@@ -8,7 +8,7 @@ public enum TokenType {
     ACCESS_TOKEN(60L * 30),
     REFRESH_TOKEN(60L * 60 * 24 * 14);
 
-    private final Long validTime;
+    public final Long validTime;
 
     TokenType(Long validTime) {
         this.validTime = validTime;

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/enums/TokenType.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/enums/TokenType.java
@@ -1,0 +1,16 @@
+package com.j2kb.jibapi.domain.user.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum TokenType {
+
+    ACCESS_TOKEN(60L * 30),
+    REFRESH_TOKEN(60L * 60 * 24 * 14);
+
+    private final Long validTime;
+
+    TokenType(Long validTime) {
+        this.validTime = validTime;
+    }
+}

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/enums/TokenType.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/enums/TokenType.java
@@ -5,12 +5,14 @@ import lombok.Getter;
 @Getter
 public enum TokenType {
 
-    ACCESS_TOKEN(60L * 30),
-    REFRESH_TOKEN(60L * 60 * 24 * 14);
+    ACCESS_TOKEN(60L * 30, "access token"),
+    REFRESH_TOKEN(60L * 60 * 24 * 14, "refresh token");
 
     public final Long validTime;
+    public final String description;
 
-    TokenType(Long validTime) {
+    TokenType(Long validTime, String description) {
         this.validTime = validTime;
+        this.description = description;
     }
 }

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/service/UserJoinService.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/service/UserJoinService.java
@@ -53,14 +53,6 @@ public class UserJoinService extends BasicServiceSupport {
         userReq.setPassword(bCryptPasswordEncoder.encode(userReq.getPassword()));
     }
 
-    /*
-    private void controlValidationImg(JoinDto.BasicReq userReq, User user) {
-        if(user.getValidationImg() != null) {
-            user.setValidationImg(userReq.getValidationImg().getBytes(StandardCharsets.UTF_8));
-        }
-    }
-     */
-
     private User getUserByUserNo(Long userNo) {
         Optional<User> user = userRepository.findByUserNo(userNo);
         return user.orElseThrow(() -> new InvalidValueException(ErrorCode.ENTITY_NOT_FOUND));

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/service/UserLoginService.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/service/UserLoginService.java
@@ -74,12 +74,9 @@ public class UserLoginService {
     }
 
     public String refreshToken(String refreshToken) {
-        // 로그아웃 상태 or refresh token이 만료된 상태에서 refresh 요청
         refreshTokenRedisRepository.findById(refreshToken)
             .orElseThrow(() -> new EntityNotFoundException("토큰 정보가 만료되었습니다. 다시 로그인해주세요."));
         UserPrincipal userPrincipal = tokenProvider.getUserPrincipal(refreshToken);
-        System.out.println(userPrincipal);
-        // 이 상황에서는 다시 refresh token을 다시 generate하게 됨.
         return tokenProvider.generateToken(tokenProvider.getUserPrincipal(refreshToken), TokenType.ACCESS_TOKEN);
     }
 }

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/service/UserLoginService.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/service/UserLoginService.java
@@ -79,4 +79,8 @@ public class UserLoginService {
         UserPrincipal userPrincipal = tokenProvider.getUserPrincipal(refreshToken);
         return tokenProvider.generateToken(tokenProvider.getUserPrincipal(refreshToken), TokenType.ACCESS_TOKEN);
     }
+
+    public void signout(String refreshToken) {
+        refreshTokenRedisRepository.delete(RefreshToken.builder().token(refreshToken).build());
+    }
 }

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/service/UserLoginService.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/service/UserLoginService.java
@@ -10,7 +10,11 @@ import com.j2kb.jibapi.domain.user.dao.UserRepository;
 import com.j2kb.jibapi.domain.user.dto.LoginDto;
 import com.j2kb.jibapi.domain.user.entity.User;
 import com.j2kb.jibapi.global.config.security.UserPrincipal;
+import com.j2kb.jibapi.global.error.exception.BusinessException;
 import com.j2kb.jibapi.global.error.exception.EntityNotFoundException;
+import com.j2kb.jibapi.global.error.exception.ErrorCode;
+import com.j2kb.jibapi.global.error.exception.InvalidTokenException;
+import com.j2kb.jibapi.global.error.exception.InvalidValueException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +49,7 @@ public class UserLoginService {
     private User findByEmailAndPassword(LoginDto.Req req) {
         User user = findByEmail(req.getEmail());
         if (!passwordEncoder.matches(req.getPassword(), user.getPassword())) {
-            throw new IllegalArgumentException("잘못된 비밀번호입니다.");
+            throw new BusinessException("잘못된 비밀번호입니다.",  ErrorCode.UNAUTHORIZED);
         }
         return user;
     }
@@ -77,7 +81,7 @@ public class UserLoginService {
 
     public String refreshToken(String refreshToken) {
         refreshTokenRedisRepository.findById(refreshToken)
-            .orElseThrow(() -> new EntityNotFoundException("토큰 정보가 만료되었습니다. 다시 로그인해주세요."));
+            .orElseThrow(() -> new InvalidTokenException(TokenType.REFRESH_TOKEN));
         return tokenProvider.generateToken(tokenProvider.getUserPrincipal(refreshToken), TokenType.ACCESS_TOKEN);
     }
 

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/service/UserLoginService.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/service/UserLoginService.java
@@ -68,7 +68,9 @@ public class UserLoginService {
 
         // save refresh token to redis
         refreshTokenRedisRepository.save(RefreshToken.builder()
-                .token(tokenDto.getRefreshToken()).build());
+                .token(tokenDto.getRefreshToken())
+                .timeToLive(TokenType.REFRESH_TOKEN.getValidTime())
+            .build());
 
         return tokenDto;
     }
@@ -76,7 +78,6 @@ public class UserLoginService {
     public String refreshToken(String refreshToken) {
         refreshTokenRedisRepository.findById(refreshToken)
             .orElseThrow(() -> new EntityNotFoundException("토큰 정보가 만료되었습니다. 다시 로그인해주세요."));
-        UserPrincipal userPrincipal = tokenProvider.getUserPrincipal(refreshToken);
         return tokenProvider.generateToken(tokenProvider.getUserPrincipal(refreshToken), TokenType.ACCESS_TOKEN);
     }
 

--- a/jib-api/src/main/java/com/j2kb/jibapi/domain/user/service/UserLoginService.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/domain/user/service/UserLoginService.java
@@ -68,7 +68,6 @@ public class UserLoginService {
 
         // save refresh token to redis
         refreshTokenRedisRepository.save(RefreshToken.builder()
-                .email(userPrincipal.getEmail())
                 .token(tokenDto.getRefreshToken()).build());
 
         return tokenDto;
@@ -78,7 +77,9 @@ public class UserLoginService {
         // 로그아웃 상태 or refresh token이 만료된 상태에서 refresh 요청
         refreshTokenRedisRepository.findById(refreshToken)
             .orElseThrow(() -> new EntityNotFoundException("토큰 정보가 만료되었습니다. 다시 로그인해주세요."));
-
+        UserPrincipal userPrincipal = tokenProvider.getUserPrincipal(refreshToken);
+        System.out.println(userPrincipal);
+        // 이 상황에서는 다시 refresh token을 다시 generate하게 됨.
         return tokenProvider.generateToken(tokenProvider.getUserPrincipal(refreshToken), TokenType.ACCESS_TOKEN);
     }
 }

--- a/jib-api/src/main/java/com/j2kb/jibapi/global/config/security/UserPrincipal.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/global/config/security/UserPrincipal.java
@@ -39,8 +39,6 @@ public class UserPrincipal implements UserDetails, Serializable {
     }
 
     public static UserPrincipal create(User user) {
-        System.out.println("UserPrincipal.create");
-        System.out.println(user);
         return new UserPrincipal(
                 user.getUserNo()
                 , user.getEmail()
@@ -101,8 +99,6 @@ public class UserPrincipal implements UserDetails, Serializable {
     }
 
     public Map<String,Object> toClaims(){
-        System.out.println("UserPrincipal.toClaims");
-        System.out.println(this);
         return ImmutableMap.<String,Object>builder()
                 .put("no", this.userNo)
                 .put("email", this.email)

--- a/jib-api/src/main/java/com/j2kb/jibapi/global/config/security/UserPrincipal.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/global/config/security/UserPrincipal.java
@@ -39,6 +39,8 @@ public class UserPrincipal implements UserDetails, Serializable {
     }
 
     public static UserPrincipal create(User user) {
+        System.out.println("UserPrincipal.create");
+        System.out.println(user);
         return new UserPrincipal(
                 user.getUserNo()
                 , user.getEmail()
@@ -99,10 +101,16 @@ public class UserPrincipal implements UserDetails, Serializable {
     }
 
     public Map<String,Object> toClaims(){
+        System.out.println("UserPrincipal.toClaims");
+        System.out.println(this);
         return ImmutableMap.<String,Object>builder()
                 .put("no", this.userNo)
                 .put("email", this.email)
                 .put("type", this.userType)
+                .put("firstName", this.fistName)
+                .put("lastName", this.lastName)
+                .put("userType", this.userType)
+                .put("authorities", this.authorities)
                 .build();
     }
 }

--- a/jib-api/src/main/java/com/j2kb/jibapi/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -36,7 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Authentication authentication = tokenProvider.getAuthentication(jwt);
             SecurityContextHolder.getContext().setAuthentication(authentication);
             log.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
-        } else {
+        } else if (!tokenProvider.validateToken(jwt)){
             log.debug("유효한 JWT 토큰이 없습니다, uri: {}", requestURI);
         }
 

--- a/jib-api/src/main/java/com/j2kb/jibapi/global/config/security/jwt/TokenProvider.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/global/config/security/jwt/TokenProvider.java
@@ -57,22 +57,29 @@ public class TokenProvider implements InitializingBean {
 
     // 토큰에 담겨 있는 권한 정보를 이용해 Authentication 객체를 리턴한다.
     public Authentication getAuthentication(String token) {
-        Claims claims = Jwts
-            .parserBuilder()
-            .setSigningKey(key)
-            .build()
-            .parseClaimsJws(token)
-            .getBody();
+        Claims claims = getClaims(token);
 
         Collection<SimpleGrantedAuthority> authorities = new ArrayList<>();
         authorities.add(new SimpleGrantedAuthority("ROLE_" + claims.get(AUTHORITIES_KEY).toString()));
 
         User user = User.valueOf(claims);
-        
-        user.setPassword(user.getPassword());
+
         UserPrincipal principal = UserPrincipal.create(user);
 
         return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    public UserPrincipal getUserPrincipal(String token) {
+        return UserPrincipal.create(User.valueOf(getClaims(token)));
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts
+            .parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
     }
 
     // 토큰을 검증하는 역할을 수행한다.

--- a/jib-api/src/main/java/com/j2kb/jibapi/global/error/exception/ErrorCode.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/global/error/exception/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
     ENTITY_NOT_FOUND(400, "C003", " Entity Not Found"),
     INTERNAL_SERVER_ERROR(500, "C004", "Server Error"),
     INVALID_TYPE_VALUE(400, "C005", " Invalid Type Value"),
-    HANDLE_ACCESS_DENIED(403, "C006", "Access is Denied");
+    HANDLE_ACCESS_DENIED(403, "C006", "Access is Denied"),
+    UNAUTHORIZED(401, "C007", "Unauthorized");
 
     private String code;
     private String message;

--- a/jib-api/src/main/java/com/j2kb/jibapi/global/error/exception/InvalidTokenException.java
+++ b/jib-api/src/main/java/com/j2kb/jibapi/global/error/exception/InvalidTokenException.java
@@ -1,0 +1,22 @@
+package com.j2kb.jibapi.global.error.exception;
+
+import com.j2kb.jibapi.domain.user.enums.TokenType;
+
+public class InvalidTokenException extends BusinessException {
+
+    public InvalidTokenException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+
+    public InvalidTokenException(String message) {
+        super(message, ErrorCode.UNAUTHORIZED);
+    }
+
+    public InvalidTokenException(TokenType tokenType) {
+        super(tokenType.getDescription() + " is not valid.", ErrorCode.UNAUTHORIZED);
+    }
+
+    public InvalidTokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/jib-api/src/main/resources/application.properties
+++ b/jib-api/src/main/resources/application.properties
@@ -9,7 +9,6 @@ spring.jpa.open-in-view=false
 # jwt
 jwt.header=Authorization
 jwt.secret=4oCYajJrYi1qaWItc3ByaW5nLWJvb3Qtand0LXNlY3JldC1rZXktYmFja2VuZC1zcHJpbmctYm9vdC1qd3Qtc2VjcmV0LWtleS1mb3Itamli4oCZCg==
-jwt.token-validity-in-seconds=86400
 
 #PostgreSQL
 spring.datasource.driverClassName=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
@@ -45,7 +44,7 @@ spring.redis.port=6379
 #dynamodb
 spring.dynamodb.endpoint=http://localhost:8000
 
-#3
+# S3
 cloud.aws.s3.bucket=mkhwangbucket
 cloud.aws.s3.domain=https://mkhwangbucket.s3.ap-northeast-2.amazonaws.com/
 cloud.aws.region.static=ap-northeast-2

--- a/jib-api/src/main/resources/application.properties
+++ b/jib-api/src/main/resources/application.properties
@@ -14,9 +14,9 @@ jwt.secret=4oCYajJrYi1qaWItc3ByaW5nLWJvb3Qtand0LXNlY3JldC1rZXktYmFja2VuZC1zcHJpb
 spring.datasource.driverClassName=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
 spring.datasource.sql-script-encoding=UTF-8
 spring.datasource.platform=postgres
-spring.datasource.url=jdbc:log4jdbc:postgresql://jib.cf4kvxqmyfzl.ap-northeast-2.rds.amazonaws.com:5432/postgres
-spring.datasource.username=jibuser
-spring.datasource.password=jib!23
+spring.datasource.url=jdbc:log4jdbc:postgresql://jibdb.cf4kvxqmyfzl.ap-northeast-2.rds.amazonaws.com:5432/postgres
+spring.datasource.username=jib
+spring.datasource.password=j2kbjib!23
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.default_schema=jib
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
@@ -35,7 +35,6 @@ spring.mail.protocol=smtp
 spring.mail.properties.mail.smtp.auth=false
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.debug=true
-
 
 #redis
 spring.redis.host=localhost


### PR DESCRIPTION
## 이슈번호
#5 - 인증 기능 개선: JWT refresh token

## 작업 내역
### 토큰 발급
- TokenProvider의 generateToken() 메서드에서 refresh token 발급
- refresh token 과 access token을 담을 TokenDto 작성
- token 정보(유효시간 등)를 가져올 TokenType enum 작성

### authenticate 시 토큰 처리
- UserLoginService.authenticate() 메서드에서 TokenProvider의 generateToken을 호출해서 TokenDto를 받는다.
- 이때, AccessToken은 리턴해서 authenticate를 호출한 곳 (login, signup) 에서 response로 access token을 사용하도록 만든다.
- refresh token은 redis에 저장한다. 이를 위해 refreshToken entity와 refreshTokenRedisRepository를 작성한다.

### 로그인 시 accessToken 검증, refreshToken 조회
- access token 이 유효하지 않다면, redis에서 refresh token을 조회한다. 
- refresh token이 없다면, 프론트에서 로그아웃 처리를 하도록 적절한 응답을 준다.
- refresh token이 있다면, access token을 생성하여 발급한다.

### 로그아웃 시 redis에 refresh token 정보 삭제
- 로그아웃 기능 추가
- 로그아웃 시 refresh token 삭제

### 인증 플로우
현재 JIB 서버는 인증 서버가 분리되어 있지 않지만, 인증 API 와 다른 API 를 구분하기 위해 다음과 같이 표현하였습니다. 
![image](https://user-images.githubusercontent.com/50407047/125991669-fcfe0c4f-27d0-47a2-ba04-4d52eb7e7189.png)
![image](https://user-images.githubusercontent.com/50407047/125991721-6ebca536-ea21-466f-961b-c37b39e4bae7.png)

## 리뷰받고 싶은 포인트
- 향후 클라이언트 연동 시 클라이언트 사이드에서의 refresh token 저장소 위치
- 현재 유효하지 않은 토큰에 대한 응답이 적절한지